### PR TITLE
fix comment symbol

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,9 +1,7 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "lineComment": "#"
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
Crontab doesn't support block comments, only full-line comments.
The comment symbol for crontab files is `#` not `//`.